### PR TITLE
Fix OID for covers and nodes

### DIFF
--- a/view/vw_qgep_wastewater_structure.py
+++ b/view/vw_qgep_wastewater_structure.py
@@ -94,8 +94,8 @@ def vw_qgep_wastewater_structure(srid: int,
         {extra_joins};
        
         ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','wastewater_structure');
-        ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER co_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','structure_part');
-        ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER wn_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','wastewater_node');
+        ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER co_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','cover');
+        ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER wn_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','wastewater_networkelement');
     """.format(extra_cols='\n    '.join([select_columns(pg_cur=cursor,
                                                         table_schema=table_parts(table_def['table'])[0],
                                                         table_name=table_parts(table_def['table'])[1],
@@ -531,8 +531,8 @@ def vw_qgep_wastewater_structure(srid: int,
 
     extras = """
     ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','wastewater_structure');
-    ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER co_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','structure_part');
-    ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER wn_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','wastewater_node');
+    ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER co_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','cover');
+    ALTER VIEW qgep_od.vw_qgep_wastewater_structure ALTER wn_obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','wastewater_networkelement');
     """
     cursor.execute(extras)
 


### PR DESCRIPTION
Fix https://github.com/QGEP/QGEP/issues/519

@3nids why is the alter view defined 2 times?

This avoid having different obj_id when editing from 

qgep_od.vw_qgep_wastewater_structure
qgep_od.vw_qgep_wastewater_node
qgep_od.vw_qgep_cover