### PR TITLE
fix default values for maintenance views

### DIFF
--- a/delta/delta_1.3.2_fix_default_values_maintenance_views.sql
+++ b/delta/delta_1.3.2_fix_default_values_maintenance_views.sql
@@ -1,2 +1,2 @@
-ALTER VIEW qgep_od.vw_qgep_maintenance ALTER obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','maintenance_event');
-ALTER VIEW qgep_od.vw_qgep_damage ALTER obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','damage');
+
+-- nothing has to be done, views are automatic

--- a/delta/delta_1.3.2_fix_default_values_maintenance_views.sql
+++ b/delta/delta_1.3.2_fix_default_values_maintenance_views.sql
@@ -1,2 +1,0 @@
-
--- nothing has to be done, views are automatic

--- a/delta/delta_1.3.2_fix_default_values_maintenance_views.sql
+++ b/delta/delta_1.3.2_fix_default_values_maintenance_views.sql
@@ -1,0 +1,2 @@
+ALTER VIEW qgep_od.vw_qgep_maintenance ALTER obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','maintenance_event');
+ALTER VIEW qgep_od.vw_qgep_damage ALTER obj_id SET DEFAULT qgep_sys.generate_oid('qgep_od','damage');

--- a/view/vw_damage.yaml
+++ b/view/vw_damage.yaml
@@ -4,6 +4,7 @@ table: qgep_od.damage
 view_name: vw_qgep_damage
 allow_type_change: False
 allow_parent_only: True
+pkey_default_value: True
 
 joins:
   channel:

--- a/view/vw_maintenance_examination.yaml
+++ b/view/vw_maintenance_examination.yaml
@@ -4,6 +4,7 @@ table: qgep_od.maintenance_event
 view_name: vw_qgep_maintenance
 allow_type_change: false
 allow_parent_only: true
+pkey_default_value: True
 
 joins:
   examination:


### PR DESCRIPTION
add default values for maintenance views

this should allow working without transactions in Wincan2QGEP plugin

waiting on an upcoming pirogue version to allow defining the default values in multiple inheritance views.