### PR TITLE
Improve error messaging when SRID is missing

### DIFF
--- a/delta/post-all.py
+++ b/delta/post-all.py
@@ -14,6 +14,8 @@ class CreateViews(DeltaPy):
         qgep_wastewater_structure_extra = self.variables.get('qgep_wastewater_structure_extra', None)
         qgep_reach_extra = self.variables.get('qgep_reach_extra', None)
 
+        if not self.variables.get('SRID'):
+            raise RuntimeError('SRID not specified. Add `-v int SRID 2056` to the updgrade command.')
         create_views(srid=self.variables.get('SRID'),
                      pg_service=self.pg_service,
                      qgep_wastewater_structure_extra=qgep_wastewater_structure_extra,

--- a/delta/post-all.py
+++ b/delta/post-all.py
@@ -15,7 +15,7 @@ class CreateViews(DeltaPy):
         qgep_reach_extra = self.variables.get('qgep_reach_extra', None)
 
         if not self.variables.get('SRID'):
-            raise RuntimeError('SRID not specified. Add `-v int SRID 2056` to the updgrade command.')
+            raise RuntimeError('SRID not specified. Add `-v int SRID 2056` (or the corresponding EPSG code) to the upgrade command.')
         create_views(srid=self.variables.get('SRID'),
                      pg_service=self.pg_service,
                      qgep_wastewater_structure_extra=qgep_wastewater_structure_extra,


### PR DESCRIPTION
Currently if `-v int SRID 2056` is missing, it will fail with the following cryptic message

> Applying post-all.py... int() argument must be a string, a bytes-like object or a number, not 'NoneType'