### PR TITLE
Force catchment area connection as 2D lines

### DIFF
--- a/view/vw_catchment_area_connections.sql
+++ b/view/vw_catchment_area_connections.sql
@@ -4,10 +4,10 @@ CREATE VIEW qgep_od.vw_catchment_area_connections AS
 SELECT
 
 ca.obj_id,
-ST_MakeLine(ST_Centroid(ST_CurveToLine(perimeter_geometry)),
-wn_rw_current.situation_geometry)::geometry( LineString, %(SRID)s ) AS connection_rw_current_geometry,
-ST_MakeLine(ST_Centroid(ST_CurveToLine(perimeter_geometry)),
-wn_ww_current.situation_geometry)::geometry( LineString, %(SRID)s ) AS connection_ww_current_geometry
+ST_Force2D(ST_MakeLine(ST_Centroid(ST_CurveToLine(perimeter_geometry)),
+wn_rw_current.situation_geometry))::geometry( LineString, %(SRID)s ) AS connection_rw_current_geometry,
+ST_Force2D(ST_MakeLine(ST_Centroid(ST_CurveToLine(perimeter_geometry)),
+wn_ww_current.situation_geometry))::geometry( LineString, %(SRID)s ) AS connection_ww_current_geometry
 
 FROM qgep_od.catchment_area ca
 LEFT JOIN qgep_od.wastewater_node wn_rw_current


### PR DESCRIPTION
Catchment area connexions are lines frome WN (3D) to WN (3D). It is better to cast these as 2D.

Fix https://github.com/QGEP/QGEP/issues/521

Seen at codesprint with @m-kuhn