### PR TITLE
Run vacuum on network tests

### DIFF
--- a/test/test_network.py
+++ b/test/test_network.py
@@ -25,6 +25,7 @@ class TestNetwork(unittest.TestCase, DbTestBase):
 
     def tearDown(self):
         self.conn.rollback()
+        self.vacuum()
 
     def setUp(self):
         pgservice=os.environ.get('PGSERVICE') or 'pg_qgep'

--- a/test/utils.py
+++ b/test/utils.py
@@ -117,3 +117,11 @@ class DbTestBase:
         Helper to make 2D point geometries
         """
         return self.execute('ST_SetSrid(ST_MakePoint(%s, %s), %s)', [x, y, srid])
+
+    def vacuum(self):
+        old_isolation_level = self.conn.isolation_level
+        self.conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+        query = "VACUUM FULL"
+        cursor = self.conn.cursor()
+        cursor.execute(query)
+        self.conn.set_isolation_level(old_isolation_level)


### PR DESCRIPTION
Hopefully this fixes travis tests running out of space

https://travis-ci.org/github/QGEP/datamodel/builds/694673273#L700