### PR TITLE
Fix failing tests due to pum (and improve github CI)

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -23,6 +23,10 @@ RUN printf '[qgep_release]\ndbname=qgep_release\nuser=postgres\n' >> /etc/postgr
 RUN printf '[qgep_release_struct]\ndbname=qgep_release_struct\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
 RUN printf '[qgep_build]\ndbname=qgep_build\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
 RUN printf '[qgep_build_pum]\ndbname=qgep_build_pum\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
+RUN printf '[qgep_pum_test]\ndbname=qgep_pum_test\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
+
+# required for pum test-and-upgrade to pickup the service
+ENV PGSERVICEFILE=/etc/postgresql-common/pg_service.conf
 
 # Main script
 RUN chmod +x /src/.docker/init_qgep.sh

--- a/.docker/init_qgep.sh
+++ b/.docker/init_qgep.sh
@@ -97,13 +97,14 @@ fi
 if [ "$#" == "0" ] || [ "$1" == "build_pum" ]; then
 
   recreate_db "qgep_build_pum"
+  recreate_db "qgep_pum_test"
   echo '----------------------------------------'
-  echo "Building database through pum migrations"
+  echo "Building database through pum migrations (test-and-upgrade)"
 
   pum restore -p qgep_build_pum -x --exclude-schema public --exclude-schema topology -- ./test_data/qgep_demodata_1.0.0.dump
   PGSERVICE=qgep_build_pum psql -v ON_ERROR_STOP=on -f test_data/data_fixes.sql
   pum baseline -p qgep_build_pum -t qgep_sys.pum_info -d ./delta/ -b 1.0.0
-  pum upgrade -p qgep_build_pum -t qgep_sys.pum_info -d ./delta/ -v int SRID 2056
+  yes | pum test-and-upgrade -pp qgep_build_pum -pt qgep_pum_test -pc qgep_build -t qgep_sys.pum_info -f /tmp/dump -d ./delta/ -i constraints views --exclude-schema public -v int SRID 2056
 
   echo "Done ! Database qgep_build_pum can now be used."
   echo '----------------------------------------'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pirogue>=1.2.5
 psycopg2
 pyyaml
-pum>=0.8.4
+pum==0.9.12


### PR DESCRIPTION
This bumps pum version to fix failing/flaky tests due to indeterministic trigger ordering in pum check.

Also improves the github CI workflow so that it also uses `pum test-and-upgrade`, so that it better matches travis's results.

Note that this also pin pum's version in requirements.txt, which I think is better, as it will reduce the risk of new issues silently appearing with pum updates.