### PR TITLE
Role permissions: separate cluster initialisation from db initialisation

### DIFF
--- a/12_0_roles.sql
+++ b/12_0_roles.sql
@@ -1,0 +1,17 @@
+-------------------------------------------
+/* CREATE roles - cluster initialisation */
+-------------------------------------------
+DO $$
+DECLARE
+    role text;
+BEGIN
+    FOREACH role IN ARRAY ARRAY['qgep_viewer', 'qgep_user', 'qgep_manager', 'qgep_sysadmin'] LOOP
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role) THEN
+          EXECUTE format('CREATE ROLE %1$I NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION', role);
+      END IF;
+    END LOOP;
+END
+$$;
+GRANT qgep_viewer TO qgep_user;
+GRANT qgep_user TO qgep_manager;
+GRANT qgep_manager TO qgep_sysadmin;

--- a/12_1_roles.sql
+++ b/12_1_roles.sql
@@ -1,15 +1,6 @@
-/* create roles */
-DO $$
-DECLARE
-    role text;
-BEGIN
-    FOREACH role IN ARRAY ARRAY['qgep_viewer', 'qgep_user', 'qgep_manager', 'qgep_sysadmin'] LOOP
-      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role) THEN
-          EXECUTE format('CREATE ROLE %1$I NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION', role);
-      END IF;
-    END LOOP;
-END
-$$;
+------------------------------------------
+/* GRANT on schemas - once per database */
+------------------------------------------
 
 /* Viewer */
 GRANT USAGE ON SCHEMA qgep_od  TO qgep_viewer;
@@ -25,24 +16,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_od  GRANT SELECT, REFERENCES, TRIGGER ON
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_sys GRANT SELECT, REFERENCES, TRIGGER ON TABLES TO qgep_viewer;
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_vl  GRANT SELECT, REFERENCES, TRIGGER ON TABLES TO qgep_viewer;
 
-/*
--- Revok
-REVOKE ALL ON SCHEMA qgep_dr  FROM qgep_viewer;
-REVOKE ALL ON SCHEMA qgep_od  FROM qgep_viewer;
-REVOKE ALL ON SCHEMA qgep_sys FROM qgep_viewer;
-REVOKE ALL ON SCHEMA qgep_vl  FROM qgep_viewer;
-REVOKE ALL ON ALL TABLES IN SCHEMA qgep_dr  FROM qgep_viewer;
-REVOKE ALL ON ALL TABLES IN SCHEMA qgep_od  FROM qgep_viewer;
-REVOKE ALL ON ALL TABLES IN SCHEMA qgep_sys FROM qgep_viewer;
-REVOKE ALL ON ALL TABLES IN SCHEMA qgep_vl  FROM qgep_viewer;
-ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_dr  REVOKE ALL ON TABLES  FROM qgep_viewer;
-ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_od  REVOKE ALL ON TABLES  FROM qgep_viewer;
-ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_sys REVOKE ALL ON TABLES  FROM qgep_viewer;
-ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_vl  REVOKE ALL ON TABLES  FROM qgep_viewer;
-*/
-
 /* User */
-GRANT qgep_viewer TO qgep_user;
 GRANT ALL ON SCHEMA qgep_od TO qgep_user;
 GRANT ALL ON ALL TABLES IN SCHEMA qgep_od TO qgep_user;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA qgep_od TO qgep_user;
@@ -50,7 +24,6 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_od GRANT ALL ON TABLES TO qgep_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_od GRANT ALL ON SEQUENCES TO qgep_user;
 
 /* Manager */
-GRANT qgep_user TO qgep_manager;
 GRANT ALL ON SCHEMA qgep_vl TO qgep_manager;
 GRANT ALL ON ALL TABLES IN SCHEMA qgep_vl TO qgep_manager;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA qgep_vl TO qgep_manager;
@@ -58,9 +31,22 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_vl GRANT ALL ON TABLES TO qgep_manager;
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_vl GRANT ALL ON SEQUENCES TO qgep_manager;
 
 /* SysAdmin */
-GRANT qgep_manager TO qgep_sysadmin;
 GRANT ALL ON SCHEMA qgep_sys TO qgep_sysadmin;
 GRANT ALL ON ALL TABLES IN SCHEMA qgep_sys TO qgep_sysadmin;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA qgep_sys TO qgep_sysadmin;
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_sys GRANT ALL ON TABLES TO qgep_sysadmin;
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_sys GRANT ALL ON SEQUENCES TO qgep_sysadmin;
+
+/*
+-- Revoke
+REVOKE ALL ON SCHEMA qgep_od  FROM qgep_viewer;
+REVOKE ALL ON SCHEMA qgep_sys FROM qgep_viewer;
+REVOKE ALL ON SCHEMA qgep_vl  FROM qgep_viewer;
+REVOKE ALL ON ALL TABLES IN SCHEMA qgep_od  FROM qgep_viewer;
+REVOKE ALL ON ALL TABLES IN SCHEMA qgep_sys FROM qgep_viewer;
+REVOKE ALL ON ALL TABLES IN SCHEMA qgep_vl  FROM qgep_viewer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_od  REVOKE ALL ON TABLES  FROM qgep_viewer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_sys REVOKE ALL ON TABLES  FROM qgep_viewer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_vl  REVOKE ALL ON TABLES  FROM qgep_viewer;
+*/
+

--- a/scripts/db_setup.sh
+++ b/scripts/db_setup.sh
@@ -33,6 +33,10 @@ while getopts ":rfs:p:" opt; do
       ;;
     r)
       roles=True
+      permissions=True
+      ;;
+    p)
+      permissions=True
       ;;
     s)
       SRID=$OPTARG
@@ -85,7 +89,10 @@ ${DIR}/view/create_views.py --pg_service ${PGSERVICE} --srid ${SRID}
 
 
 if [[ $roles ]]; then
-  psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/12_roles.sql
+  psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/12_0_roles.sql
+fi
+if [[ $permissions ]]; then
+  psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/12_1_roles.sql
 fi
 
 VERSION=$(cat ${DIR}/system/CURRENT_VERSION.txt)


### PR DESCRIPTION
Untangles

 - role creation - one shot cluster initialization jobs
 - permissions - that need to be granted once per database