### PR TITLE
remove gitattributes 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto


### PR DESCRIPTION
Followup of https://github.com/QGEP/datamodel/pull/165

Does anyone care about removing .gitattributes ?

`* text=auto` is very annoying as it converts LF to CRLF on Windows, which causes issues in regards to Docker (but not only, also changes the checksum of files which created some issues in the past). It's also quite useless as I think any decent code editor/tool supports LF anyways. When CRLF are actually needed (in my experience only .bat), we should anyways version them with CRLF.
 
It's not possible to override/ignore .gitattributes file it seems. IMO devs who like `text=auto` should configure their git options.
