### PR TITLE
[roles] grant create schema to qgep_user to allow using ili2pg

### DIFF
--- a/12_1_roles.sql
+++ b/12_1_roles.sql
@@ -22,6 +22,7 @@ GRANT ALL ON ALL TABLES IN SCHEMA qgep_od TO qgep_user;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA qgep_od TO qgep_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_od GRANT ALL ON TABLES TO qgep_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA qgep_od GRANT ALL ON SEQUENCES TO qgep_user;
+DO $$ BEGIN EXECUTE 'GRANT CREATE ON DATABASE ' || (SELECT current_database()) || ' TO "qgep_user"'; END $$;  -- required for ili2pg imports/exports
 
 /* Manager */
 GRANT ALL ON SCHEMA qgep_vl TO qgep_manager;


### PR DESCRIPTION
This PR grants `CREATE SCHEMA` to the qgep_user. The goal is to allow to use ili2pg, which requires to work on a separate schema.