### PR TITLE
followup fix for long running query when updating wastewater node symbology

### DIFF
--- a/06_symbology_functions.sql
+++ b/06_symbology_functions.sql
@@ -51,6 +51,14 @@ CREATE OR REPLACE FUNCTION qgep_od.update_wastewater_node_symbology(_obj_id text
   RETURNS VOID AS
   $BODY$
 BEGIN
+
+-- Otherwise this will result in very slow query due to on_structure_part_change_networkelement
+-- being triggered for all rows. See https://github.com/QGEP/datamodel/pull/166#issuecomment-760245405
+IF _all THEN
+  RAISE INFO 'Temporarily disabling symbology triggers';
+  PERFORM qgep_sys.drop_symbology_triggers();
+END IF;
+
 UPDATE qgep_od.wastewater_node n
 SET
   _function_hierarchic = function_hierarchic,
@@ -78,6 +86,13 @@ FROM(
                                 vl_usg_curr_from.order_usage_current ASC NULLS LAST, vl_usg_curr_to.order_usage_current ASC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 ) symbology_ne
 WHERE symbology_ne.ne_obj_id = n.obj_id;
+
+-- See above
+IF _all THEN
+  RAISE INFO 'Reenabling symbology triggers';
+  PERFORM qgep_sys.create_symbology_triggers();
+END IF;
+
 END
 $BODY$
 LANGUAGE plpgsql


### PR DESCRIPTION
**WARNING this alters a delta, merge before releasing 1.5.5**

Followup on https://github.com/QGEP/datamodel/pull/166 to deals with this case : https://github.com/QGEP/datamodel/pull/166#issuecomment-760749538

We now suspend the symbology triggers inside the update_wastewater_node_symbology function.

The issue was that some triggers are run FOR EACH ROW on all wastewater_structures when updating wastewater_node, resulting in a very slow query.

Ideally we should add conditions to only run these FOR EACH ROW triggers when specific columns are changed like this
```sql
CREATE TRIGGER ...
    ...
    FOR EACH ROW
    WHEN (OLD.somefield IS DISTINCT FROM NEW.somefield)
    EXECUTE PROCEDURE ...
```
but that's a bit out of scope of #166 