### PR TITLE
fix #632 part 1/2 : set defaults values for primary keys in structure parts views

### DIFF
--- a/view/create_views.py
+++ b/view/create_views.py
@@ -42,12 +42,12 @@ def create_views(srid: int,
 
     run_sql('view/drop_views.sql', pg_service, variables)
 
-    SingleInheritance('qgep_od.structure_part', 'qgep_od.access_aid', view_name='vw_access_aid', pg_service=pg_service).create()
-    SingleInheritance('qgep_od.structure_part', 'qgep_od.benching', view_name='vw_benching', pg_service=pg_service).create()
-    SingleInheritance('qgep_od.structure_part', 'qgep_od.backflow_prevention', view_name='vw_backflow_prevention', pg_service=pg_service).create()
-    SingleInheritance('qgep_od.structure_part', 'qgep_od.cover', view_name='vw_cover', pkey_default_value=True, pg_service=pg_service).create()
-    SingleInheritance('qgep_od.structure_part', 'qgep_od.dryweather_downspout', view_name='vw_dryweather_downspout', pg_service=pg_service).create()
-    SingleInheritance('qgep_od.structure_part', 'qgep_od.dryweather_flume', view_name='vw_dryweather_flume', pg_service=pg_service).create()
+    SingleInheritance('qgep_od.structure_part', 'qgep_od.access_aid', view_name='vw_access_aid', pg_service=pg_service, pkey_default_value=True).create()
+    SingleInheritance('qgep_od.structure_part', 'qgep_od.benching', view_name='vw_benching', pg_service=pg_service, pkey_default_value=True).create()
+    SingleInheritance('qgep_od.structure_part', 'qgep_od.backflow_prevention', view_name='vw_backflow_prevention', pg_service=pg_service, pkey_default_value=True).create()
+    SingleInheritance('qgep_od.structure_part', 'qgep_od.cover', view_name='vw_cover', pg_service=pg_service, pkey_default_value=True).create()
+    SingleInheritance('qgep_od.structure_part', 'qgep_od.dryweather_downspout', view_name='vw_dryweather_downspout', pg_service=pg_service, pkey_default_value=True).create()
+    SingleInheritance('qgep_od.structure_part', 'qgep_od.dryweather_flume', view_name='vw_dryweather_flume', pg_service=pg_service, pkey_default_value=True).create()
     SingleInheritance('qgep_od.wastewater_structure', 'qgep_od.channel', view_name='vw_channel', pg_service=pg_service).create()
     SingleInheritance('qgep_od.wastewater_structure', 'qgep_od.manhole', view_name='vw_manhole', pg_service=pg_service).create()
     SingleInheritance('qgep_od.wastewater_structure', 'qgep_od.discharge_point', view_name='vw_discharge_point', pg_service=pg_service).create()


### PR DESCRIPTION
This allows QGIS to pick them up and populate default value in the forms by default.

@3nids Do you know if there's a reason we didn't do that already ?

This does not yet include logic to have this enforced at database level (discussed here https://github.com/QGEP/QGEP/issues/632#issuecomment-784980221)

This requires an update to the QGIS project.