### PR TITLE
add views for VSA-DSS subsystem property drainage

### DIFF
--- a/view/create_views.py
+++ b/view/create_views.py
@@ -57,7 +57,10 @@ def create_views(srid: int,
     SingleInheritance('qgep_od.wastewater_networkelement', 'qgep_od.wastewater_node', view_name='vw_wastewater_node', pkey_default_value=True, pg_service=pg_service).create()
 
     SingleInheritance('qgep_od.connection_object', 'qgep_od.individual_surface', view_name='vw_individual_surface', pkey_default_value=True, pg_service=pg_service).create()
-
+    SingleInheritance('qgep_od.connection_object', 'qgep_od.building', view_name='vw_building', pkey_default_value=True, pg_service=pg_service).create()
+    SingleInheritance('qgep_od.connection_object', 'qgep_od.reservoir', view_name='vw_reservoir', pkey_default_value=True, pg_service=pg_service).create()
+    SingleInheritance('qgep_od.connection_object', 'qgep_od.fountain', view_name='vw_fountain', pkey_default_value=True, pg_service=pg_service).create()
+    
     MultipleInheritance(safe_load(open("view/vw_maintenance_examination.yaml")), drop=True, pg_service=pg_service).create()
     MultipleInheritance(safe_load(open("view/vw_damage.yaml")), drop=True, pg_service=pg_service).create()
 


### PR DESCRIPTION
In order to make full use of the DSS-subsystem property drainage (Liegenschaftsentwässerung) we need the corresponding views